### PR TITLE
Add ChatGPT-style chatbot UI with configurable OpenAI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# chat_demo
+# Chat Demo
+
+A simple ChatGPT-style chatbot built with Next.js and shadcn/ui components. It connects to an OpenAI-compatible API and allows configuring the API base URL, model name, and API key. The interface supports light and dark themes.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "chat-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-themes": "0.2.1",
+    "clsx": "2.0.0",
+    "tailwind-merge": "1.14.0",
+    "@radix-ui/react-dialog": "1.0.0",
+    "lucide-react": "0.344.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.5.7",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.24",
+    "tailwindcss": "3.3.2",
+    "typescript": "5.1.6"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 255 255 255;
+  --foreground: 0 0 0;
+}
+
+.dark {
+  --background: 0 0 0;
+  --foreground: 255 255 255;
+}
+
+body {
+  background-color: rgb(var(--background));
+  color: rgb(var(--foreground));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import './globals.css'
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import { ThemeProvider } from '@/components/theme-provider'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: 'Chat Demo',
+  description: 'ChatGPT-like chatbot using shadcn/ui'
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={inter.className}>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import Chat from '@/components/chat'
+
+export default function Page() {
+  return <Chat />
+}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { SettingsDialog } from '@/components/settings-dialog'
+import { ThemeToggle } from '@/components/theme-toggle'
+
+interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export default function Chat() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [open, setOpen] = useState(false)
+  const settingsRef = useRef({ apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' })
+
+  const sendMessage = async () => {
+    if (!input) return
+    const newMessages = [...messages, { role: 'user', content: input }]
+    setMessages(newMessages)
+    setInput('')
+    try {
+      const res = await fetch(`${settingsRef.current.apiBase}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${settingsRef.current.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: settingsRef.current.model,
+          messages: newMessages,
+        }),
+      })
+      const data = await res.json()
+      const reply = data.choices?.[0]?.message?.content || 'No response'
+      setMessages(m => [...m, { role: 'assistant', content: reply }])
+    } catch (e: any) {
+      setMessages(m => [...m, { role: 'assistant', content: e.message }])
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-screen">
+      <header className="flex items-center justify-between p-4 border-b">
+        <h1 className="font-bold">Chat Demo</h1>
+        <div className="flex gap-2">
+          <ThemeToggle />
+          <Button onClick={() => setOpen(true)}>Settings</Button>
+        </div>
+      </header>
+      <main className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+            <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+              {m.content}
+            </div>
+          </div>
+        ))}
+      </main>
+      <form
+        onSubmit={e => {
+          e.preventDefault()
+          sendMessage()
+        }}
+        className="flex gap-2 p-4 border-t"
+      >
+        <input
+          className="flex-1 border rounded-md px-3 py-2 bg-white dark:bg-black"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Send a message"
+        />
+        <Button type="submit">Send</Button>
+      </form>
+      <SettingsDialog open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
+    </div>
+  )
+}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import * as React from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  settingsRef: React.MutableRefObject<{ apiBase: string; apiKey: string; model: string }>
+}
+
+export function SettingsDialog({ open, onOpenChange, settingsRef }: Props) {
+  const [apiBase, setApiBase] = React.useState(settingsRef.current.apiBase)
+  const [apiKey, setApiKey] = React.useState(settingsRef.current.apiKey)
+  const [model, setModel] = React.useState(settingsRef.current.model)
+
+  const save = () => {
+    settingsRef.current.apiBase = apiBase
+    settingsRef.current.apiKey = apiKey
+    settingsRef.current.model = model
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">API Base URL</label>
+            <Input value={apiBase} onChange={e => setApiBase(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Model</label>
+            <Input value={model} onChange={e => setModel(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">API Key</label>
+            <Input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={save}>Save</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ThemeProviderProps } from 'next-themes/dist/types'
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Button } from '@/components/ui/button'
+import { Sun, Moon } from 'lucide-react'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light')
+  return (
+    <Button onClick={toggle} aria-label="Toggle theme">
+      {theme === 'light' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </Button>
+  )
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline'
+}
+
+const variants: Record<string, string> = {
+  default: 'bg-blue-500 text-white hover:bg-blue-600',
+  outline: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-100'
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none h-10 py-2 px-4',
+        variants[variant],
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+)
+Button.displayName = 'Button'

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/50', className)}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-gray-300 bg-white p-6 shadow-lg dark:border-gray-700 dark:bg-gray-900',
+        className
+      )}
+      {...props}
+    />
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
+  <input
+    className={cn(
+      'flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+Input.displayName = 'Input'
+
+export { Input }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ['class'],
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build Next.js app with ChatGPT-like chat interface using shadcn/ui components
- add settings dialog to configure API base URL, model, and API key
- support light and dark themes with toggle

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b152263280833299b00b83fa708598