### PR TITLE
feat: add language toggle and adjust chat width

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { ThemeToggle } from '@/components/theme-toggle'
@@ -14,7 +14,29 @@ export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
+  const [lang, setLang] = useState<'en' | 'zh'>('en')
   const settingsRef = useRef({ apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' })
+
+  const t = {
+    en: {
+      title: 'Chat Demo',
+      settings: 'Settings',
+      placeholder: 'Send a message',
+      send: 'Send',
+      toggleLang: '中文',
+    },
+    zh: {
+      title: '聊天演示',
+      settings: '设置',
+      placeholder: '发送消息',
+      send: '发送',
+      toggleLang: 'EN',
+    },
+  }[lang]
+
+  useEffect(() => {
+    document.documentElement.lang = lang
+  }, [lang])
 
   const sendMessage = async () => {
     if (!input) return
@@ -42,12 +64,13 @@ export default function Chat() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col h-screen w-full max-w-3xl mx-auto">
       <header className="flex items-center justify-between p-4 border-b">
-        <h1 className="font-bold">Chat Demo</h1>
+        <h1 className="font-bold">{t.title}</h1>
         <div className="flex gap-2">
           <ThemeToggle />
-          <Button onClick={() => setOpen(true)}>Settings</Button>
+          <Button onClick={() => setLang(lang === 'en' ? 'zh' : 'en')}>{t.toggleLang}</Button>
+          <Button onClick={() => setOpen(true)}>{t.settings}</Button>
         </div>
       </header>
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
@@ -70,11 +93,11 @@ export default function Chat() {
           className="flex-1 border rounded-md px-3 py-2 bg-white dark:bg-black"
           value={input}
           onChange={e => setInput(e.target.value)}
-          placeholder="Send a message"
+          placeholder={t.placeholder}
         />
-        <Button type="submit">Send</Button>
+        <Button type="submit">{t.send}</Button>
       </form>
-      <SettingsDialog open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
+      <SettingsDialog lang={lang} open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
     </div>
   )
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -9,12 +9,32 @@ interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
   settingsRef: React.MutableRefObject<{ apiBase: string; apiKey: string; model: string }>
+  lang: 'en' | 'zh'
 }
 
-export function SettingsDialog({ open, onOpenChange, settingsRef }: Props) {
+export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props) {
   const [apiBase, setApiBase] = React.useState(settingsRef.current.apiBase)
   const [apiKey, setApiKey] = React.useState(settingsRef.current.apiKey)
   const [model, setModel] = React.useState(settingsRef.current.model)
+
+  const t = {
+    en: {
+      title: 'Settings',
+      apiBase: 'API Base URL',
+      model: 'Model',
+      apiKey: 'API Key',
+      cancel: 'Cancel',
+      save: 'Save',
+    },
+    zh: {
+      title: '设置',
+      apiBase: 'API 地址',
+      model: '模型',
+      apiKey: 'API 密钥',
+      cancel: '取消',
+      save: '保存',
+    },
+  }[lang]
 
   const save = () => {
     settingsRef.current.apiBase = apiBase
@@ -27,27 +47,27 @@ export function SettingsDialog({ open, onOpenChange, settingsRef }: Props) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Settings</DialogTitle>
+          <DialogTitle>{t.title}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 py-2">
           <div className="space-y-1">
-            <label className="text-sm font-medium">API Base URL</label>
+            <label className="text-sm font-medium">{t.apiBase}</label>
             <Input value={apiBase} onChange={e => setApiBase(e.target.value)} />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium">Model</label>
+            <label className="text-sm font-medium">{t.model}</label>
             <Input value={model} onChange={e => setModel(e.target.value)} />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium">API Key</label>
+            <label className="text-sm font-medium">{t.apiKey}</label>
             <Input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} />
           </div>
         </div>
         <div className="flex justify-end gap-2 pt-2">
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            {t.cancel}
           </Button>
-          <Button onClick={save}>Save</Button>
+          <Button onClick={save}>{t.save}</Button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- limit chat layout width for better spacing
- add Chinese/English toggle for chat and settings dialog

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b15663731c8332b854b91c807e362e