### PR TITLE
feat: support markdown output and icon-based Chinese UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "clsx": "2.0.0",
     "tailwind-merge": "1.14.0",
     "@radix-ui/react-dialog": "1.0.0",
-    "lucide-react": "0.344.0"
+    "lucide-react": "0.344.0",
+    "react-markdown": "^8.0.5"
   },
   "devDependencies": {
     "@types/node": "20.5.7",

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -4,7 +4,8 @@ import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { ThemeToggle } from '@/components/theme-toggle'
-import { Loader2 } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import { Loader2, Languages, Settings, Send } from 'lucide-react'
 
 interface Message {
   role: 'user' | 'assistant'
@@ -15,7 +16,7 @@ export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
-  const [lang, setLang] = useState<'en' | 'zh'>('en')
+  const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
   const settingsRef = useRef({ apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' })
 
@@ -110,15 +111,19 @@ export default function Chat() {
         <h1 className="font-bold">{t.title}</h1>
         <div className="flex gap-2">
           <ThemeToggle />
-          <Button onClick={() => setLang(lang === 'en' ? 'zh' : 'en')}>{t.toggleLang}</Button>
-          <Button onClick={() => setOpen(true)}>{t.settings}</Button>
+          <Button onClick={() => setLang(lang === 'en' ? 'zh' : 'en')} aria-label={t.toggleLang}>
+            <Languages className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => setOpen(true)} aria-label={t.settings}>
+            <Settings className="h-4 w-4" />
+          </Button>
         </div>
       </header>
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((m, i) => (
           <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
-              {m.content}
+              <ReactMarkdown>{m.content}</ReactMarkdown>
               {loading && i === messages.length - 1 && m.role === 'assistant' && (
                 <Loader2 className="w-4 h-4 ml-1 inline animate-spin" />
               )}
@@ -139,7 +144,9 @@ export default function Chat() {
           onChange={e => setInput(e.target.value)}
           placeholder={t.placeholder}
         />
-        <Button type="submit">{t.send}</Button>
+        <Button type="submit" aria-label={t.send}>
+          <Send className="h-4 w-4" />
+        </Button>
       </form>
       <SettingsDialog lang={lang} open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
     </div>

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Save, X } from 'lucide-react'
 
 interface Props {
   open: boolean
@@ -64,10 +65,12 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
           </div>
         </div>
         <div className="flex justify-end gap-2 pt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {t.cancel}
+          <Button variant="outline" onClick={() => onOpenChange(false)} aria-label={t.cancel}>
+            <X className="h-4 w-4" />
           </Button>
-          <Button onClick={save}>{t.save}</Button>
+          <Button onClick={save} aria-label={t.save}>
+            <Save className="h-4 w-4" />
+          </Button>
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary
- render chat messages with Markdown
- default interface language to Chinese
- replace text buttons with icons

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b15ddb81a48332b80cff2d3bde29a1