### PR TITLE
feat: support markdown tables and formulas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "tailwind-merge": "1.14.0",
     "@radix-ui/react-dialog": "1.0.0",
     "lucide-react": "0.344.0",
-    "react-markdown": "^8.0.5"
+    "react-markdown": "^8.0.5",
+    "remark-gfm": "^3.0.1",
+    "remark-math": "^5.1.1",
+    "rehype-katex": "^6.0.3",
+    "katex": "^0.16.9"
   },
   "devDependencies": {
     "@types/node": "20.5.7",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css'
+import 'katex/dist/katex.min.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -5,6 +5,9 @@ import { Button } from '@/components/ui/button'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { ThemeToggle } from '@/components/theme-toggle'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
 import { Loader2, Languages, Settings, Send } from 'lucide-react'
 
 interface Message {
@@ -123,7 +126,12 @@ export default function Chat() {
         {messages.map((m, i) => (
           <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
-              <ReactMarkdown>{m.content}</ReactMarkdown>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkMath]}
+                rehypePlugins={[rehypeKatex]}
+              >
+                {m.content}
+              </ReactMarkdown>
               {loading && i === messages.length - 1 && m.role === 'assistant' && (
                 <Loader2 className="w-4 h-4 ml-1 inline animate-spin" />
               )}


### PR DESCRIPTION
## Summary
- allow tables and math in chat markdown via remark and rehype plugins
- include KaTeX styles for rendering formulas
- ignore generated directories

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b161bf0f8c83328f0859c54b8b903b