### PR TITLE
feat: add code highlighting for markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "rehype-katex": "^6.0.3",
-    "katex": "^0.16.9"
+    "katex": "^0.16.9",
+    "rehype-highlight": "^7.0.0",
+    "highlight.js": "^11.8.0"
   },
   "devDependencies": {
     "@types/node": "20.5.7",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import 'katex/dist/katex.min.css'
+import 'highlight.js/styles/github.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -8,6 +8,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import rehypeHighlight from 'rehype-highlight'
 import { Loader2, Languages, Settings, Send } from 'lucide-react'
 
 interface Message {
@@ -128,7 +129,7 @@ export default function Chat() {
             <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
-                rehypePlugins={[rehypeKatex]}
+                rehypePlugins={[rehypeKatex, rehypeHighlight]}
               >
                 {m.content}
               </ReactMarkdown>


### PR DESCRIPTION
## Summary
- support syntax highlighting in rendered Markdown
- include highlight.js styles globally
- add rehype-highlight and highlight.js dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16a4d45548332bbdac5f09f8af21f