### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -10,10 +10,19 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import rehypeHighlight from 'rehype-highlight'
 import { Loader2, Languages, Settings, Send } from 'lucide-react'
+import { CodeBlock } from '@/components/code-block'
 
 interface Message {
   role: 'user' | 'assistant'
   content: string
+}
+
+function getNodeText(node: any): string {
+  if (!node) return ''
+  if (typeof node === 'string') return node
+  if (node.type === 'text') return node.value
+  if (Array.isArray(node.children)) return node.children.map(getNodeText).join('')
+  return ''
 }
 
 export default function Chat() {
@@ -130,6 +139,26 @@ export default function Chat() {
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[rehypeKatex, rehypeHighlight]}
+                components={{
+                  code({ node, inline, className, children, ...props }: any) {
+                    const text = getNodeText(node)
+                    if (inline) {
+                      return (
+                        <code
+                          className="rounded bg-gray-200 px-1 text-sm dark:bg-gray-700"
+                          {...props}
+                        >
+                          {children}
+                        </code>
+                      )
+                    }
+                    return (
+                      <CodeBlock className={className} code={text}>
+                        {children}
+                      </CodeBlock>
+                    )
+                  }
+                }}
               >
                 {m.content}
               </ReactMarkdown>

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useState } from 'react'
+import { Copy, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface CodeBlockProps {
+  className?: string
+  code: string
+  children: React.ReactNode
+}
+
+export function CodeBlock({ className, code, children }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false)
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {}
+  }
+
+  return (
+    <div className="relative group">
+      <pre className="overflow-x-auto rounded-lg p-4 text-sm">
+        <code className={cn(className)}>{children}</code>
+      </pre>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="absolute right-2 top-2 rounded bg-gray-200 p-1 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+        aria-label="Copy code"
+      >
+        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `CodeBlock` component with clipboard support
- render markdown code blocks with copy button and smaller font

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ff93b20833291211b48315b4ad4