### PR TITLE
feat: cache settings

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -26,12 +26,31 @@ function getNodeText(node: any): string {
 }
 
 export default function Chat() {
-  const [messages, setMessages] = useState<Message[]>([])
+  const [messages, setMessages] = useState<Message[]>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('messages')
+      if (stored) {
+        try {
+          return JSON.parse(stored)
+        } catch {}
+      }
+    }
+    return []
+  })
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
   const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
-  const settingsRef = useRef({ apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' })
+  const defaultSettings = { apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' }
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('settings')
+    if (stored) {
+      try {
+        Object.assign(defaultSettings, JSON.parse(stored))
+      } catch {}
+    }
+  }
+  const settingsRef = useRef(defaultSettings)
 
   const t = {
     en: {
@@ -53,6 +72,10 @@ export default function Chat() {
   useEffect(() => {
     document.documentElement.lang = lang
   }, [lang])
+
+  useEffect(() => {
+    localStorage.setItem('messages', JSON.stringify(messages))
+  }, [messages])
 
   const sendMessage = async () => {
     if (!input) return

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -18,6 +18,14 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
   const [apiKey, setApiKey] = React.useState(settingsRef.current.apiKey)
   const [model, setModel] = React.useState(settingsRef.current.model)
 
+  React.useEffect(() => {
+    if (open) {
+      setApiBase(settingsRef.current.apiBase)
+      setApiKey(settingsRef.current.apiKey)
+      setModel(settingsRef.current.model)
+    }
+  }, [open, settingsRef])
+
   const t = {
     en: {
       title: 'Settings',
@@ -38,9 +46,9 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
   }[lang]
 
   const save = () => {
-    settingsRef.current.apiBase = apiBase
-    settingsRef.current.apiKey = apiKey
-    settingsRef.current.model = model
+    const newSettings = { apiBase, apiKey, model }
+    settingsRef.current = newSettings
+    localStorage.setItem('settings', JSON.stringify(newSettings))
     onOpenChange(false)
   }
 


### PR DESCRIPTION
## Summary
- persist API settings in localStorage to avoid re-entering each visit
- store and restore chat history so conversations survive page reloads

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b184f56318833284693d1fffb08e8f