### PR TITLE
feat: add system prompt setting

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -13,7 +13,7 @@ import { Loader2, Languages, Settings, Send } from 'lucide-react'
 import { CodeBlock } from '@/components/code-block'
 
 interface Message {
-  role: 'user' | 'assistant'
+  role: 'system' | 'user' | 'assistant'
   content: string
 }
 
@@ -41,7 +41,12 @@ export default function Chat() {
   const [open, setOpen] = useState(false)
   const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
-  const defaultSettings = { apiBase: '', apiKey: '', model: 'gpt-3.5-turbo' }
+  const defaultSettings = {
+    apiBase: '',
+    apiKey: '',
+    model: 'gpt-3.5-turbo',
+    systemPrompt: '',
+  }
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('settings')
     if (stored) {
@@ -93,7 +98,9 @@ export default function Chat() {
         },
         body: JSON.stringify({
           model: settingsRef.current.model,
-          messages: newMessages,
+          messages: settingsRef.current.systemPrompt
+            ? [{ role: 'system', content: settingsRef.current.systemPrompt }, ...newMessages]
+            : newMessages,
           stream: true,
         }),
       })

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -4,12 +4,18 @@ import * as React from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Save, X } from 'lucide-react'
 
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
-  settingsRef: React.MutableRefObject<{ apiBase: string; apiKey: string; model: string }>
+  settingsRef: React.MutableRefObject<{
+    apiBase: string
+    apiKey: string
+    model: string
+    systemPrompt: string
+  }>
   lang: 'en' | 'zh'
 }
 
@@ -17,12 +23,16 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
   const [apiBase, setApiBase] = React.useState(settingsRef.current.apiBase)
   const [apiKey, setApiKey] = React.useState(settingsRef.current.apiKey)
   const [model, setModel] = React.useState(settingsRef.current.model)
+  const [systemPrompt, setSystemPrompt] = React.useState(
+    settingsRef.current.systemPrompt
+  )
 
   React.useEffect(() => {
     if (open) {
       setApiBase(settingsRef.current.apiBase)
       setApiKey(settingsRef.current.apiKey)
       setModel(settingsRef.current.model)
+      setSystemPrompt(settingsRef.current.systemPrompt)
     }
   }, [open, settingsRef])
 
@@ -32,6 +42,7 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
       apiBase: 'API Base URL',
       model: 'Model',
       apiKey: 'API Key',
+      systemPrompt: 'System Prompt',
       cancel: 'Cancel',
       save: 'Save',
     },
@@ -40,13 +51,14 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
       apiBase: 'API 地址',
       model: '模型',
       apiKey: 'API 密钥',
+      systemPrompt: '系统提示词',
       cancel: '取消',
       save: '保存',
     },
   }[lang]
 
   const save = () => {
-    const newSettings = { apiBase, apiKey, model }
+    const newSettings = { apiBase, apiKey, model, systemPrompt }
     settingsRef.current = newSettings
     localStorage.setItem('settings', JSON.stringify(newSettings))
     onOpenChange(false)
@@ -70,6 +82,14 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
           <div className="space-y-1">
             <label className="text-sm font-medium">{t.apiKey}</label>
             <Input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">{t.systemPrompt}</label>
+            <Textarea
+              value={systemPrompt}
+              onChange={e => setSystemPrompt(e.target.value)}
+              rows={3}
+            />
           </div>
         </div>
         <div className="flex justify-end gap-2 pt-2">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    className={cn(
+      'flex w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    ref={ref}
+    {...props}
+  />
+))
+Textarea.displayName = 'Textarea'
+
+export { Textarea }


### PR DESCRIPTION
## Summary
- allow configuring system prompt via settings
- include system prompt when sending chat requests

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b18a802de4833299b09ec15836c202