### PR TITLE
Fix hydration mismatch in theme toggle

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -3,10 +3,24 @@
 import { useTheme } from 'next-themes'
 import { Button } from '@/components/ui/button'
 import { Sun, Moon } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
   const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light')
+
+  if (!mounted) {
+    return (
+      <Button aria-label="Toggle theme">
+        <Sun className="h-4 w-4" />
+      </Button>
+    )
+  }
+
   return (
     <Button onClick={toggle} aria-label="Toggle theme">
       {theme === 'light' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}


### PR DESCRIPTION
## Summary
- prevent hydration mismatch in theme toggle by rendering icon only after mount

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a520a0b08332847bcc5f0cfeaff2