### PR TITLE
Remove component-specific styling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,7 @@ import './globals.css'
 import 'katex/dist/katex.min.css'
 import 'highlight.js/styles/github.css'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Chat Demo',
@@ -15,7 +12,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}
         </ThemeProvider>

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -150,10 +150,10 @@ export default function Chat() {
   }
 
   return (
-    <div className="flex flex-col h-screen w-full max-w-3xl mx-auto">
-      <header className="flex items-center justify-between p-4 border-b">
-        <h1 className="font-bold">{t.title}</h1>
-        <div className="flex gap-2">
+    <div>
+      <header>
+        <h1>{t.title}</h1>
+        <div>
           <ThemeToggle />
           <Button
             onClick={() => {
@@ -163,22 +163,21 @@ export default function Chat() {
               }
             }}
             aria-label={t.clear}
-            className="bg-red-500 hover:bg-red-600 text-white"
           >
-            <Trash2 className="h-4 w-4" />
+            <Trash2 />
           </Button>
           <Button onClick={() => setLang(lang === 'en' ? 'zh' : 'en')} aria-label={t.toggleLang}>
-            <Languages className="h-4 w-4" />
+            <Languages />
           </Button>
           <Button onClick={() => setOpen(true)} aria-label={t.settings}>
-            <Settings className="h-4 w-4" />
+            <Settings />
           </Button>
         </div>
       </header>
-      <main className="flex-1 overflow-y-auto p-4 space-y-4">
+      <main>
         {messages.map((m, i) => (
-          <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
-            <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+          <div key={i}>
+            <div>
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[rehypeKatex, rehypeHighlight]}
@@ -186,14 +185,7 @@ export default function Chat() {
                   code({ node, inline, className, children, ...props }: any) {
                     const text = getNodeText(node)
                     if (inline) {
-                      return (
-                        <code
-                          className="rounded bg-gray-200 px-1 text-sm dark:bg-gray-700"
-                          {...props}
-                        >
-                          {children}
-                        </code>
-                      )
+                      return <code {...props}>{children}</code>
                     }
                     return (
                       <CodeBlock className={className} code={text}>
@@ -206,7 +198,7 @@ export default function Chat() {
                 {m.content}
               </ReactMarkdown>
               {loading && i === messages.length - 1 && m.role === 'assistant' && (
-                <Loader2 className="w-4 h-4 ml-1 inline animate-spin" />
+                <Loader2 />
               )}
             </div>
           </div>
@@ -217,16 +209,14 @@ export default function Chat() {
           e.preventDefault()
           sendMessage()
         }}
-        className="flex gap-2 p-4 border-t"
       >
         <input
-          className="flex-1 border rounded-md px-3 py-2 bg-white dark:bg-black"
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder={t.placeholder}
         />
         <Button type="submit" aria-label={t.send}>
-          <Send className="h-4 w-4" />
+          <Send />
         </Button>
       </form>
       <SettingsDialog lang={lang} open={open} onOpenChange={setOpen} settingsRef={settingsRef} />

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { Copy, Check } from 'lucide-react'
-import { cn } from '@/lib/utils'
 
 interface CodeBlockProps {
   className?: string
@@ -22,17 +21,12 @@ export function CodeBlock({ className, code, children }: CodeBlockProps) {
   }
 
   return (
-    <div className="relative">
-      <pre className="overflow-x-auto rounded-lg p-4 text-sm">
-        <code className={cn(className)}>{children}</code>
+    <div>
+      <pre>
+        <code className={className}>{children}</code>
       </pre>
-      <button
-        type="button"
-        onClick={onCopy}
-        className="absolute right-2 top-2 rounded bg-gray-200 p-1 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-        aria-label="Copy code"
-      >
-        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      <button type="button" onClick={onCopy} aria-label="Copy code">
+        {copied ? <Check /> : <Copy />}
       </button>
     </div>
   )

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -70,21 +70,21 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
         <DialogHeader>
           <DialogTitle>{t.title}</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4 py-2">
-          <div className="space-y-1">
-            <label className="text-sm font-medium">{t.apiBase}</label>
+        <div>
+          <div>
+            <label>{t.apiBase}</label>
             <Input value={apiBase} onChange={e => setApiBase(e.target.value)} />
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-medium">{t.model}</label>
+          <div>
+            <label>{t.model}</label>
             <Input value={model} onChange={e => setModel(e.target.value)} />
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-medium">{t.apiKey}</label>
+          <div>
+            <label>{t.apiKey}</label>
             <Input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} />
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-medium">{t.systemPrompt}</label>
+          <div>
+            <label>{t.systemPrompt}</label>
             <Textarea
               value={systemPrompt}
               onChange={e => setSystemPrompt(e.target.value)}
@@ -92,12 +92,12 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
             />
           </div>
         </div>
-        <div className="flex justify-end gap-2 pt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)} aria-label={t.cancel}>
-            <X className="h-4 w-4" />
+        <div>
+          <Button onClick={() => onOpenChange(false)} aria-label={t.cancel}>
+            <X />
           </Button>
           <Button onClick={save} aria-label={t.save}>
-            <Save className="h-4 w-4" />
+            <Save />
           </Button>
         </div>
       </DialogContent>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -16,14 +16,14 @@ export function ThemeToggle() {
   if (!mounted) {
     return (
       <Button aria-label="Toggle theme">
-        <Sun className="h-4 w-4" />
+        <Sun />
       </Button>
     )
   }
 
   return (
     <Button onClick={toggle} aria-label="Toggle theme">
-      {theme === 'light' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      {theme === 'light' ? <Sun /> : <Moon />}
     </Button>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,27 +1,8 @@
 import * as React from 'react'
-import { cn } from '@/lib/utils'
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'outline'
-}
-
-const variants: Record<string, string> = {
-  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-  outline:
-    'border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground',
-}
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'default', ...props }, ref) => (
-    <button
-      className={cn(
-        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background h-10 px-4 py-2',
-        variants[variant],
-        className
-      )}
-      ref={ref}
-      {...props}
-    />
-  )
+  (props, ref) => <button ref={ref} {...props} />
 )
 Button.displayName = 'Button'

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { cn } from '@/lib/utils'
 
 const Dialog = DialogPrimitive.Root
 const DialogTrigger = DialogPrimitive.Trigger
@@ -12,48 +11,27 @@ const DialogClose = DialogPrimitive.Close
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-background/80 backdrop-blur-sm', className)}
-    {...props}
-  />
-))
+>((props, ref) => <DialogPrimitive.Overlay ref={ref} {...props} />)
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>((props, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-lg rounded-lg',
-        className
-      )}
-      {...props}
-    />
+    <DialogPrimitive.Content ref={ref} {...props} />
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
-)
+const DialogHeader = (props: React.HTMLAttributes<HTMLDivElement>) => <div {...props} />
 DialogHeader.displayName = 'DialogHeader'
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-))
+>((props, ref) => <DialogPrimitive.Title ref={ref} {...props} />)
 DialogTitle.displayName = DialogPrimitive.Title.displayName
 
 export {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react'
-import { cn } from '@/lib/utils'
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
-  <input
-    className={cn(
-      'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-      className
-    )}
-    ref={ref}
-    {...props}
-  />
+const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => (
+  <input ref={ref} {...props} />
 ))
 Input.displayName = 'Input'
 

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,17 +1,9 @@
 import * as React from 'react'
-import { cn } from '@/lib/utils'
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
-  <textarea
-    className={cn(
-      'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-      className
-    )}
-    ref={ref}
-    {...props}
-  />
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>((props, ref) => (
+  <textarea ref={ref} {...props} />
 ))
 Textarea.displayName = 'Textarea'
 


### PR DESCRIPTION
## Summary
- Remove component-level class names to rely solely on `app/globals.css`
- Simplify UI elements (Button, Input, Textarea, Dialog) to plain HTML structure
- Drop font-specific styling from layout and icons

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'tailwindcss-animate')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TS5090 baseUrl not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c7034fa083329db0a7f080faadc9