### PR TITLE
feat: enable horizontal scrolling in code blocks

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -179,7 +179,7 @@ export default function Chat() {
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.map((m, i) => (
           <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
-            <div className="inline-block rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+            <div className="inline-block max-w-full rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm, remarkMath]}
                 rehypePlugins={[rehypeKatex, rehypeHighlight as any]}

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -23,7 +23,7 @@ export function CodeBlock({ className, code, children }: CodeBlockProps) {
 
   return (
     <div className="relative">
-      <pre className="overflow-x-auto rounded-lg p-4 text-sm">
+      <pre className="overflow-x-auto rounded-lg p-4 text-sm w-full">
         <code className={cn(className)}>{children}</code>
       </pre>
       <button


### PR DESCRIPTION
## Summary
- ensure code blocks expand only to container width and enable horizontal scrolling
- limit chat message bubble width to avoid overflowing

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b50b2e785883329149a7a30a0d1c8e