### PR TITLE
feat: add dark theme support to CodeBlock

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -11,6 +11,7 @@ import rehypeKatex from 'rehype-katex'
 import rehypeHighlight from 'rehype-highlight'
 import { Loader2, Languages, Settings, Send, Trash2 } from 'lucide-react'
 import { CodeBlock } from '@/components/code-block'
+import { useTheme } from 'next-themes'
 
 type RoleType = 'system' | 'user' | 'assistant'
 interface Message {
@@ -32,6 +33,7 @@ export default function Chat() {
   const [open, setOpen] = useState(false)
   const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
+  const { theme } = useTheme()
   const defaultSettings = {
     apiBase: '',
     apiKey: '',
@@ -197,7 +199,11 @@ export default function Chat() {
                       )
                     }
                     return (
-                      <CodeBlock className={className} code={text}>
+                      <CodeBlock
+                        className={className}
+                        code={text}
+                        theme={theme === 'dark' ? 'dark' : 'light'}
+                      >
                         {children}
                       </CodeBlock>
                     )

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -8,9 +8,13 @@ interface CodeBlockProps {
   className?: string
   code: string
   children: React.ReactNode
+  /**
+   * Visual theme for the code block. Defaults to `light`.
+   */
+  theme?: 'light' | 'dark'
 }
 
-export function CodeBlock({ className, code, children }: CodeBlockProps) {
+export function CodeBlock({ className, code, children, theme = 'light' }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
 
   const onCopy = async () => {
@@ -23,13 +27,25 @@ export function CodeBlock({ className, code, children }: CodeBlockProps) {
 
   return (
     <div className="relative">
-      <pre className="overflow-x-auto rounded-lg p-4 text-sm w-full">
+      <pre
+        className={cn(
+          'overflow-x-auto rounded-lg p-4 text-sm w-full',
+          theme === 'dark'
+            ? 'bg-gray-900 text-gray-100'
+            : 'bg-gray-100 text-gray-900'
+        )}
+      >
         <code className={cn(className)}>{children}</code>
       </pre>
       <button
         type="button"
         onClick={onCopy}
-        className="absolute right-2 top-2 rounded bg-gray-200 p-1 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+        className={cn(
+          'absolute right-2 top-2 rounded p-1',
+          theme === 'dark'
+            ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+        )}
         aria-label="Copy code"
       >
         {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}


### PR DESCRIPTION
## Summary
- allow CodeBlock to switch between light and dark themes
- propagate current theme from Chat component to CodeBlock

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b52c2537e0833286da83304a814d11