### PR TITLE
feat: enhance code block styling

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -5,13 +5,7 @@ import { Button } from '@/components/ui/button'
 import { SettingsDialog } from '@/components/settings-dialog'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Markdown } from '@/components/markdown'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import remarkMath from 'remark-math'
-import rehypeKatex from 'rehype-katex'
-import rehypeHighlight from 'rehype-highlight'
 import { Loader2, Languages, Settings, Send, Trash2 } from 'lucide-react'
-import { CodeBlock } from '@/components/code-block'
 
 type RoleType = 'system' | 'user' | 'assistant'
 interface Message {

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -2,15 +2,12 @@
 
 import { useState } from 'react'
 import { Copy, Check } from 'lucide-react'
-import { cn } from '@/lib/utils'
-
 interface CodeBlockProps {
-  className?: string
   code: string
   children: React.ReactNode
 }
 
-export function CodeBlock({ className, code, children }: CodeBlockProps) {
+export function CodeBlock({ code, children }: CodeBlockProps) {
   const [copied, setCopied] = useState(false)
 
   const onCopy = async () => {
@@ -23,9 +20,7 @@ export function CodeBlock({ className, code, children }: CodeBlockProps) {
 
   return (
     <div className="relative">
-      <pre className="overflow-x-auto rounded-lg text-sm w-full">
-        <code className={cn(className)}>{children}</code>
-      </pre>
+      {children}
       <button
         type="button"
         onClick={onCopy}

--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -5,7 +5,8 @@ import RemarkBreaks from 'remark-breaks'
 import RehypeKatex from 'rehype-katex'
 import RemarkGfm from 'remark-gfm'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { atelierHeathLight } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import { CodeBlock } from '@/components/code-block'
 
 export function Markdown(props: { content: string }) {
   return (
@@ -18,22 +19,25 @@ export function Markdown(props: { content: string }) {
         components={{
           code({ node, inline, className, children, ...props }) {
             const match = /language-(\w+)/.exec(className || '')
-            return (!inline && match)
-              ? (
+            const codeString = String(children).replace(/\n$/, '')
+            return !inline && match ? (
+              <CodeBlock code={codeString}>
                 <SyntaxHighlighter
                   {...props}
-                  children={String(children).replace(/\n$/, '')}
-                  style={atelierHeathLight}
+                  style={atomOneDark}
                   language={match[1]}
                   showLineNumbers
+                  customStyle={{ margin: 0, fontSize: '0.875rem', borderRadius: '0.5rem' }}
                   PreTag="div"
-                />
-              )
-              : (
-                <code {...props} className={className}>
-                  {children}
-                </code>
-              )
+                >
+                  {codeString}
+                </SyntaxHighlighter>
+              </CodeBlock>
+            ) : (
+              <code {...props} className={className}>
+                {children}
+              </code>
+            )
           },
         }}
         linkTarget="_blank"


### PR DESCRIPTION
## Summary
- use a dark theme for Markdown code blocks
- add a copy button and smaller font size to code blocks
- clean up unused imports in chat component

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b54aaaec188332b97cc8468d706ba5