### PR TITLE
feat: sync code highlight with theme

### DIFF
--- a/src/components/markdown.tsx
+++ b/src/components/markdown.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import ReactMarkdown from 'react-markdown'
 import 'katex/dist/katex.min.css'
 import RemarkMath from 'remark-math'
@@ -5,17 +7,22 @@ import RemarkBreaks from 'remark-breaks'
 import RehypeKatex from 'rehype-katex'
 import RemarkGfm from 'remark-gfm'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { atomOneDark } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import {
+  atomOneDark,
+  atomOneLight,
+} from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import { useTheme } from 'next-themes'
 import { CodeBlock } from '@/components/code-block'
 
 export function Markdown(props: { content: string }) {
+  const { theme } = useTheme()
+  const codeStyle = theme === 'dark' ? atomOneDark : atomOneLight
+
   return (
     <div className="markdown-body">
       <ReactMarkdown
         remarkPlugins={[RemarkMath, RemarkGfm, RemarkBreaks]}
-        rehypePlugins={[
-          RehypeKatex,
-        ]}
+        rehypePlugins={[RehypeKatex]}
         components={{
           code({ node, inline, className, children, ...props }) {
             const match = /language-(\w+)/.exec(className || '')
@@ -24,7 +31,7 @@ export function Markdown(props: { content: string }) {
               <CodeBlock code={codeString}>
                 <SyntaxHighlighter
                   {...props}
-                  style={atomOneDark}
+                  style={codeStyle}
                   language={match[1]}
                   showLineNumbers
                   customStyle={{ margin: 0, fontSize: '0.875rem', borderRadius: '0.5rem' }}


### PR DESCRIPTION
## Summary
- dynamically choose light/dark code highlight styles based on current theme

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b54f1dcb7c8332a448ead2d4fe0527