### PR TITLE
feat: extract settings into config

### DIFF
--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from '@/components/theme-toggle'
 import { Markdown } from '@/components/markdown'
 import Toast from '@/components/toast'
 import { Loader2, Languages, Settings, Send, Trash2 } from 'lucide-react'
+import { loadSettings, AppSettings } from '@/config'
 
 type RoleType = 'system' | 'user' | 'assistant'
 interface Message {
@@ -28,21 +29,7 @@ export default function Chat() {
   const [open, setOpen] = useState(false)
   const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
-  const defaultSettings = {
-    apiBase: '',
-    apiKey: '',
-    model: 'gpt-3.5-turbo',
-    systemPrompt: '',
-  }
-  if (typeof window !== 'undefined') {
-    const stored = localStorage.getItem('settings')
-    if (stored) {
-      try {
-        Object.assign(defaultSettings, JSON.parse(stored))
-      } catch {}
-    }
-  }
-  const settingsRef = useRef(defaultSettings)
+  const settingsRef = useRef<AppSettings>(loadSettings())
 
   const t = {
     en: {

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -6,16 +6,12 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Save, X } from 'lucide-react'
+import { AppSettings, saveSettings } from '@/config'
 
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
-  settingsRef: React.MutableRefObject<{
-    apiBase: string
-    apiKey: string
-    model: string
-    systemPrompt: string
-  }>
+  settingsRef: React.MutableRefObject<AppSettings>
   lang: 'en' | 'zh'
 }
 
@@ -58,9 +54,9 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
   }[lang]
 
   const save = () => {
-    const newSettings = { apiBase, apiKey, model, systemPrompt }
+    const newSettings: AppSettings = { apiBase, apiKey, model, systemPrompt }
     settingsRef.current = newSettings
-    localStorage.setItem('settings', JSON.stringify(newSettings))
+    saveSettings(newSettings)
     onOpenChange(false)
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,33 @@
+export interface AppSettings {
+  apiBase: string
+  apiKey: string
+  model: string
+  systemPrompt: string
+}
+
+export const defaultSettings: AppSettings = {
+  apiBase: '',
+  apiKey: '',
+  model: 'gpt-3.5-turbo',
+  systemPrompt: '',
+}
+
+export function loadSettings(): AppSettings {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('settings')
+    if (stored) {
+      try {
+        return { ...defaultSettings, ...JSON.parse(stored) }
+      } catch {
+        return defaultSettings
+      }
+    }
+  }
+  return defaultSettings
+}
+
+export function saveSettings(settings: AppSettings) {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('settings', JSON.stringify(settings))
+  }
+}


### PR DESCRIPTION
## Summary
- add central config with default settings and load/save helpers
- refactor chat component to use config for settings
- refactor settings dialog to persist settings via config

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b64ec0c98c83328d7d1afbaed50a02