### PR TITLE
feat: use base service for chat

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,12 @@ export interface AppSettings {
   systemPrompt: string
 }
 
+export let API_PREFIX = ''
+
+export function setApiBase(base: string) {
+  API_PREFIX = base
+}
+
 export const defaultSettings: AppSettings = {
   apiBase: '',
   apiKey: '',
@@ -13,21 +19,24 @@ export const defaultSettings: AppSettings = {
 }
 
 export function loadSettings(): AppSettings {
+  let settings = defaultSettings
   if (typeof window !== 'undefined') {
     const stored = localStorage.getItem('settings')
     if (stored) {
       try {
-        return { ...defaultSettings, ...JSON.parse(stored) }
+        settings = { ...defaultSettings, ...JSON.parse(stored) }
       } catch {
-        return defaultSettings
+        settings = defaultSettings
       }
     }
   }
-  return defaultSettings
+  setApiBase(settings.apiBase)
+  return settings
 }
 
 export function saveSettings(settings: AppSettings) {
   if (typeof window !== 'undefined') {
     localStorage.setItem('settings', JSON.stringify(settings))
   }
+  setApiBase(settings.apiBase)
 }

--- a/src/service/base.ts
+++ b/src/service/base.ts
@@ -1,4 +1,4 @@
-// import { API_PREFIX } from '@/config'
+import { API_PREFIX } from '@/config'
 import Toast from '@/components/toast'
 import type { AnnotationReply, MessageEnd, MessageReplace, ThoughtItem } from '@/components/chat-type'
 // import type { VisionFile } from '@/types/app'


### PR DESCRIPTION
## Summary
- expose API prefix configuration and update on settings change
- integrate chat component with base service stream API

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b68a20e39c8332a253d14edd0f78db