### PR TITLE
chore: add OpenAI response interface

### DIFF
--- a/src/service/base.ts
+++ b/src/service/base.ts
@@ -2,6 +2,7 @@ import { API_PREFIX } from '@/config'
 import Toast from '@/components/toast'
 import type { AnnotationReply, MessageEnd, MessageReplace, ThoughtItem } from '@/components/chat-type'
 // import type { VisionFile } from '@/types/app'
+import type { OpenAIResponse } from '@/types/openai'
 
 export enum TransferMethod {
   all = 'all',
@@ -249,12 +250,13 @@ const handleStream = (
             else if (bufferObj.event === 'node_finished') {
               onNodeFinished?.(bufferObj as NodeFinishedResponse)
             }
-            else if (bufferObj.choices) {
-              const content = bufferObj.choices?.[0]?.delta?.content
+            else if ((bufferObj as OpenAIResponse).choices) {
+              const openaiRes = bufferObj as OpenAIResponse
+              const content = openaiRes.choices?.[0]?.delta?.content
               if (content) {
                 onData(content, isFirstMessage, {
-                  conversationId: bufferObj.id,
-                  messageId: bufferObj.id,
+                  conversationId: openaiRes.id,
+                  messageId: openaiRes.id,
                 })
                 isFirstMessage = false
               }

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -1,0 +1,14 @@
+export interface OpenAIResponse {
+  id: string
+  object: string
+  created: number
+  model: string
+  choices: {
+    delta?: {
+      role?: string
+      content?: string
+    }
+    index: number
+    finish_reason: string | null
+  }[]
+}


### PR DESCRIPTION
## Summary
- add OpenAIResponse interface to describe streaming OpenAI chunks
- use OpenAIResponse in service stream handler for type safety

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0ba1b4c833283c516610901251c