### PR TITLE
feat: integrate react i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "sass": "^1.91.0",
+    "i18next": "^23.4.6",
+    "react-i18next": "^13.2.2",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7",
     "use-context-selector": "^2.0.0"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './styles/markdown.scss'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'
+import i18n from '@/i18n'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -14,7 +15,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={i18n.language} suppressHydrationWarning>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -9,6 +9,8 @@ import Toast from '@/components/toast'
 import { Loader2, Languages, Settings, Send, Trash2 } from 'lucide-react'
 import { loadSettings, AppSettings } from '@/config'
 import { ssePost } from '@/service/base'
+import { useTranslation } from 'react-i18next'
+import '@/i18n'
 
 type RoleType = 'system' | 'user' | 'assistant'
 interface Message {
@@ -28,34 +30,13 @@ export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
   const [open, setOpen] = useState(false)
-  const [lang, setLang] = useState<'en' | 'zh'>('zh')
   const [loading, setLoading] = useState(false)
   const settingsRef = useRef<AppSettings>(loadSettings())
-
-  const t = {
-    en: {
-      title: 'Chat Demo',
-      settings: 'Settings',
-      placeholder: 'Send a message',
-      send: 'Send',
-      toggleLang: '中文',
-      clear: 'Clear',
-      msgEmpty: 'Message is empty',
-    },
-    zh: {
-      title: '聊天演示',
-      settings: '设置',
-      placeholder: '发送消息',
-      send: '发送',
-      toggleLang: 'EN',
-      clear: '清空',
-      msgEmpty: '消息不能为空',
-    },
-  }[lang]
+  const { t, i18n } = useTranslation()
 
   useEffect(() => {
-    document.documentElement.lang = lang
-  }, [lang])
+    document.documentElement.lang = i18n.language
+  }, [i18n.language])
 
   useEffect(() => {
     const stored = localStorage.getItem('messages')
@@ -72,7 +53,7 @@ export default function Chat() {
 
   const sendMessage = () => {
     if (!input) {
-      Toast.notify({ type: 'error', message: t.msgEmpty })
+      Toast.notify({ type: 'error', message: t('chat.msgEmpty') })
       return
     }
     const userMessage = { role: 'user', content: input }
@@ -125,7 +106,7 @@ export default function Chat() {
   return (
     <div className="flex flex-col h-screen w-full max-w-3xl mx-auto">
       <header className="flex items-center justify-between p-4 border-b border-border">
-        <h1 className="font-bold">{t.title}</h1>
+        <h1 className="font-bold">{t('chat.title')}</h1>
         <div className="flex gap-2">
           <ThemeToggle />
           <Button
@@ -135,15 +116,15 @@ export default function Chat() {
                 localStorage.removeItem('messages')
               }
             }}
-            aria-label={t.clear}
+            aria-label={t('chat.clear')}
             className="bg-red-500 hover:bg-red-600 text-white"
           >
             <Trash2 className="h-4 w-4" />
           </Button>
-          <Button onClick={() => setLang(lang === 'en' ? 'zh' : 'en')} aria-label={t.toggleLang}>
+          <Button onClick={() => i18n.changeLanguage(i18n.language === 'en' ? 'zh' : 'en')} aria-label={t('chat.toggleLang')}>
             <Languages className="h-4 w-4" />
           </Button>
-          <Button onClick={() => setOpen(true)} aria-label={t.settings}>
+          <Button onClick={() => setOpen(true)} aria-label={t('chat.settings')}>
             <Settings className="h-4 w-4" />
           </Button>
         </div>
@@ -152,7 +133,7 @@ export default function Chat() {
         {messages.map((m, i) => (
           <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
             <div className="inline-block max-w-full rounded-lg px-3 py-2 bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100">
-               <Markdown content={m.content} />
+              <Markdown content={m.content} />
               {loading && i === messages.length - 1 && m.role === 'assistant' && (
                 <Loader2 className="w-4 h-4 ml-1 inline animate-spin" />
               )}
@@ -171,13 +152,13 @@ export default function Chat() {
           className="flex-1 border rounded-md px-3 py-2 bg-white dark:bg-black"
           value={input}
           onChange={e => setInput(e.target.value)}
-          placeholder={t.placeholder}
+          placeholder={t('chat.placeholder')}
         />
-        <Button type="submit" aria-label={t.send}>
+        <Button type="submit" aria-label={t('chat.send')}>
           <Send className="h-4 w-4" />
         </Button>
       </form>
-      <SettingsDialog lang={lang} open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
+      <SettingsDialog open={open} onOpenChange={setOpen} settingsRef={settingsRef} />
     </div>
   )
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -7,21 +7,23 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Save, X } from 'lucide-react'
 import { AppSettings, saveSettings } from '@/config'
+import { useTranslation } from 'react-i18next'
+import '@/i18n'
 
 interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
   settingsRef: React.MutableRefObject<AppSettings>
-  lang: 'en' | 'zh'
 }
 
-export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props) {
+export function SettingsDialog({ open, onOpenChange, settingsRef }: Props) {
   const [apiBase, setApiBase] = React.useState(settingsRef.current.apiBase)
   const [apiKey, setApiKey] = React.useState(settingsRef.current.apiKey)
   const [model, setModel] = React.useState(settingsRef.current.model)
   const [systemPrompt, setSystemPrompt] = React.useState(
     settingsRef.current.systemPrompt
   )
+  const { t } = useTranslation()
 
   React.useEffect(() => {
     if (open) {
@@ -31,27 +33,6 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
       setSystemPrompt(settingsRef.current.systemPrompt)
     }
   }, [open, settingsRef])
-
-  const t = {
-    en: {
-      title: 'Settings',
-      apiBase: 'API Base URL',
-      model: 'Model',
-      apiKey: 'API Key',
-      systemPrompt: 'System Prompt',
-      cancel: 'Cancel',
-      save: 'Save',
-    },
-    zh: {
-      title: '设置',
-      apiBase: 'API 地址',
-      model: '模型',
-      apiKey: 'API 密钥',
-      systemPrompt: '系统提示词',
-      cancel: '取消',
-      save: '保存',
-    },
-  }[lang]
 
   const save = () => {
     const newSettings: AppSettings = { apiBase, apiKey, model, systemPrompt }
@@ -64,23 +45,23 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t.title}</DialogTitle>
+          <DialogTitle>{t('settings.title')}</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 py-2">
           <div className="space-y-1">
-            <label className="text-sm font-medium">{t.apiBase}</label>
+            <label className="text-sm font-medium">{t('settings.apiBase')}</label>
             <Input value={apiBase} onChange={e => setApiBase(e.target.value)} />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium">{t.model}</label>
+            <label className="text-sm font-medium">{t('settings.model')}</label>
             <Input value={model} onChange={e => setModel(e.target.value)} />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium">{t.apiKey}</label>
+            <label className="text-sm font-medium">{t('settings.apiKey')}</label>
             <Input type="password" value={apiKey} onChange={e => setApiKey(e.target.value)} />
           </div>
           <div className="space-y-1">
-            <label className="text-sm font-medium">{t.systemPrompt}</label>
+            <label className="text-sm font-medium">{t('settings.systemPrompt')}</label>
             <Textarea
               value={systemPrompt}
               onChange={e => setSystemPrompt(e.target.value)}
@@ -89,10 +70,10 @@ export function SettingsDialog({ open, onOpenChange, settingsRef, lang }: Props)
           </div>
         </div>
         <div className="flex justify-end gap-2 pt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)} aria-label={t.cancel}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} aria-label={t('settings.cancel')}>
             <X className="h-4 w-4" />
           </Button>
-          <Button onClick={save} aria-label={t.save}>
+          <Button onClick={save} aria-label={t('settings.save')}>
             <Save className="h-4 w-4" />
           </Button>
         </div>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,19 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import zh from './locales/zh.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      zh: { translation: zh }
+    },
+    lng: 'zh',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false }
+  });
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,20 @@
+{
+  "chat": {
+    "title": "Chat Demo",
+    "settings": "Settings",
+    "placeholder": "Send a message",
+    "send": "Send",
+    "toggleLang": "中文",
+    "clear": "Clear",
+    "msgEmpty": "Message is empty"
+  },
+  "settings": {
+    "title": "Settings",
+    "apiBase": "API Base URL",
+    "model": "Model",
+    "apiKey": "API Key",
+    "systemPrompt": "System Prompt",
+    "cancel": "Cancel",
+    "save": "Save"
+  }
+}

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1,0 +1,20 @@
+{
+  "chat": {
+    "title": "聊天演示",
+    "settings": "设置",
+    "placeholder": "发送消息",
+    "send": "发送",
+    "toggleLang": "EN",
+    "clear": "清空",
+    "msgEmpty": "消息不能为空"
+  },
+  "settings": {
+    "title": "设置",
+    "apiBase": "API 地址",
+    "model": "模型",
+    "apiKey": "API 密钥",
+    "systemPrompt": "系统提示词",
+    "cancel": "取消",
+    "save": "保存"
+  }
+}


### PR DESCRIPTION
## Summary
- add i18next and react-i18next configuration
- translate chat and settings dialog components
- initialize language resources and dynamic html lang

## Testing
- `npm test`
- `npm run lint` *(fails: required interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b5fbfa80833289bed11601173e25