### PR TITLE
fix i18next server component error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import './styles/markdown.scss'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import { ThemeProvider } from '@/components/theme-provider'
-import i18n from '@/i18n'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -15,7 +14,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang={i18n.language} suppressHydrationWarning>
+    <html lang="zh" suppressHydrationWarning>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import en from './locales/en.json';


### PR DESCRIPTION
## Summary
- avoid importing i18n on server layout and hardcode default language
- mark i18n initialization as client-only to access React context

## Testing
- `npm test`
- `npm run lint` *(fails: prompted for ESLint setup)*
- `npm run build` *(fails: failed to fetch Inter font; module not found i18next/react-i18next)*


------
https://chatgpt.com/codex/tasks/task_e_68b6d07af5d08332990a0f73b4e973fc